### PR TITLE
feat: heartbeat通知の送信先を#system_alert_infoに変更

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -31,6 +31,11 @@ func CreateSlackClient() *slack.Slack {
 		dc = "#bot_sandbox"
 	}
 
+	hc := os.Getenv("HEARTBEAT_CHANNEL")
+	if len(hc) == 0 {
+		hc = "#system_alert_info"
+	}
+
 	enabled := false
 	switch s := os.Getenv("SLACK_DEFAULT_ENABLED"); s {
 	case "true":
@@ -44,6 +49,7 @@ func CreateSlackClient() *slack.Slack {
 	return &slack.Slack{
 		Token:            os.Getenv("SLACK_TOKEN"),
 		DefaultChannel:   dc,
+		HeartbeatChannel: hc,
 		Title:            "job notify",
 		NotifyCondisions: []string{"Failed"},
 		DefaultEnabled:   enabled,

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -25,6 +25,7 @@ Rerun command: %s
 type Slack struct {
 	Token            string
 	DefaultChannel   string
+	HeartbeatChannel string
 	Title            string
 	NotifyCondisions []string
 	DefaultEnabled   bool
@@ -183,13 +184,15 @@ func buildAttachment(job *batchv1.Job, matched *batchv1.JobCondition, s *Slack) 
 	return attachment
 }
 
-// PostHeartbeat sends a liveness message to the default Slack channel.
-// It is used to detect silent failures (e.g. the informer failing to sync,
-// or an expired Slack token) that would otherwise leave the notifier stuck
-// forever without producing any error log or CronJob notification.
+// PostHeartbeat sends a liveness message to the heartbeat Slack channel
+// (separate from DefaultChannel, which is used for Job/CronJob failure
+// notifications). It is used to detect silent failures (e.g. the informer
+// failing to sync, or an expired Slack token) that would otherwise leave the
+// notifier stuck forever without producing any error log or CronJob
+// notification.
 func (s *Slack) PostHeartbeat(message string) error {
 	client := slack.New(s.Token)
-	_, _, err := client.PostMessage(s.DefaultChannel,
+	_, _, err := client.PostMessage(s.HeartbeatChannel,
 		slack.MsgOptionText(message, false),
 		slack.MsgOptionAsUser(false),
 		slack.MsgOptionIconEmoji(":sushi:"))
@@ -198,6 +201,6 @@ func (s *Slack) PostHeartbeat(message string) error {
 		return err
 	}
 
-	log.Printf("Heartbeat successfully sent to channel %s", s.DefaultChannel)
+	log.Printf("Heartbeat successfully sent to channel %s", s.HeartbeatChannel)
 	return nil
 }


### PR DESCRIPTION
## Summary
- heartbeat通知(起動時+24時間ごとのalive通知)の送信先を、CronJob失敗通知と同じ`DEFAULT_CHANNEL`(#job-notify / #job-notify-stg)から、専用の`HEARTBEAT_CHANNEL`(未設定時は`#system_alert_info`)に変更
- 失敗通知チャンネルにheartbeatのノイズが混ざらないようにするための変更（PR #9で導入したheartbeat機能へのフィードバック）

## Changes
- `slack.Slack`に`HeartbeatChannel`フィールドを追加、`PostHeartbeat`はこのチャンネル宛に送信
- `handler.CreateSlackClient()`で`HEARTBEAT_CHANNEL`環境変数を読み込み（未設定時デフォルト`#system_alert_info`）。既存のConfigMapに変更なしでもこのデフォルトが有効になる

## Test plan
- [x] `go build ./...` / `go vet ./...` / `go test ./...` 成功
- [ ] マージ後、staging/productionへrollout restart → heartbeatが`#system_alert_info`に届くことを確認