### PR TITLE
CircleCI: docker executor の job を Gen2 リソースクラスに変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
     parallelism: 2
     environment:
       TEST_RESULTS: /tmp/test-results
+    resource_class: medium.gen2
     steps:
       - checkout
       - run: mkdir -p $TEST_RESULTS


### PR DESCRIPTION
## 概要

CircleCI の **docker executor の job のみ** Gen2 リソースクラス（`.gen2` サフィックス）に変更します。

`machine`（Linux VM）/ `remote-docker` / `macos` の job は**対象外**です（後述の実測により不採用）。

## 変更内容

`.circleci/config.yml` の `resource_class` のみ、1 箇所。
`parallelism` / steps / workflow 構造 / `machine.image` / 他ファイルは変更していません。

| 対象 | job / executor | before | after |
| --- | --- | --- | --- |
| job | `test` | `(未指定=medium)` | `medium.gen2` |

**世代は `machine.image` ではなく `resource_class` のサフィックス**で決まります（[docs](https://circleci.com/docs/guides/execution-managed/using-linuxvm/)）。

## docker 系を Gen2 にする根拠

**単価**: Docker は Gen1 → Gen2 で **+20%**（`medium` なら 10 → 12 credits/min）。vCPU / RAM は変わりません。
損益分岐点は **16.7% の時間短縮**（`1 - 10/12`）です。

CircleCI は Gen2 Docker について「gen1 比 1.4x 高速（= −29% 短縮）」と公表しています
（[changelog](https://circleci.com/changelog/introducing-gen2-docker-x86-resource-classes/)）。

先行して 4 サービス（cam / mc / ws / wd）で実測し、**本番リリース済み**です。docker 系のテスト job は
すべて分岐点を大きく上回りました。

| service | job | Gen1 | n | Gen2 | n | 時間変化 | 1回コスト |
| --- | --- | --- | --- | --- | --- | --- | --- |
| medical_check | `vitest` | 270s | 132 | 137s | 4 | **−49%** | −39% |
| medical_check | `rspec` | 265s | 133 | 140s | 4 | **−47%** | −36% |
| company_account_manager | `rspec` | 271s | 24 | 120s | 1 | **−56%** | −47% |
| wellness_drill | `test` | 159s | 10 | 65s | 4 | **−59%** | −51% |
| wellness_survey | `rspec` | 525s | 103 | 344s | 5 | **−34%** | −21% |

リリース後の実測で、4 サービス合計 **月 −16,509 credits（−18.3%）**、
**PR 上の待ち時間 −34〜−59%** を確認しています。

## Linux VM / remote-docker を対象外にする根拠

`remote-docker` は Docker の課金表ではなく **Linux VM の表**で課金されます。
Gen1 ではどちらも 10 credits/min ですが、**Gen2 で 12 と 18 に分かれます**。

| executor | Gen1 | Gen2 | 分岐点 |
| --- | --- | --- | --- |
| Docker `medium` | 10 | 12 | **16.7%** |
| Linux VM / Remote Docker `medium` | 10 | **18** | **44.4%** |

3 サービスの実測では、Linux VM 系は 4 条件すべてで分岐点未達でした。

| service | job | 条件 | Gen1 | n | Gen2 | n | 時間 | コスト |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| medical_check | `build` | フル + DLC ミス | 546s | 8 | 468s | 2 | −14% | **+54%** |
| wellness_drill | `build` | フル + DLC ヒット | 336s | 1 | 276s | 2 | −18% | **+48%** |
| wellness_survey | `build` | assets フル | 1080s | 4 | 927s | 1 | −14% | **+55%** |
| wellness_survey | `*-migration` | remote-docker | 186s | 32 | 215s | 3 | **+16%** | **+108%** |

`build` は docker レイヤ操作・ECR push・ディスク I/O が主体で CPU 律速ではなく、
`*-migration` は kubectl の rollout 待ちの比率が大きいため、単価 1.8 倍を回収できません。

`macos` は別料金体系（`m4pro.medium` は実測 199.9 credits/min）で Gen2 の対象外です。

## 待ち時間主体の job について

kubectl の rollout 待ちが主体の deploy 系 job は、時間短縮が分岐点に届かず微増する場合があります。

**docker executor の job は世代を揃える方針とし、この程度の増加は許容します。**
世代の切り分けは「docker か Linux VM / remote-docker か」という**課金表の境界**で行っており
（分岐点が 16.7% と 44.4% で 2.7 倍違うため）、同じ課金表の中で job ごとに世代を混在させることは
していません。混在させると、job を追加・変更するたびに個別の実測と判断が必要になり、設定の
一貫性と保守性を損ないます。

## 確認方法

- [ ] 全 job が成功すること
- [ ] 割当リソースが `*-gen2docker` になっていること
      （CircleCI API v1.1 の `picard.resource_class.class` で確認）
- [ ] Gen2 Docker の前提（**有料プラン必須**、**IP Ranges / Arm Docker 非対応**）に該当しないこと
- [ ] マージ後に実測すること。**`build` 系はキャッシュ条件を揃えて比較**しないと符号が逆転します
      （`Execute assets:precompile` と `docker build` の step 所要時間で条件を判定）
- [ ] メモリに余裕の無い job が無いこと。**Docker Gen2 の RAM は Gen1 と同一**なので RAM 逼迫は改善しません

## ロールバック方法

- この PR を revert（`.circleci/config.yml` のみ）
- 個別に戻す場合は該当 job の `resource_class` から `.gen2` を外す

## スコープ外

- **Linux VM / remote-docker / macOS の job**（上記のとおり不採用）
- **Linux VM の Gen3（`*.gen3`、Beta）** — Gen1 より安いが、Gen2 の Beta 時に
  `Preview pricing shown above may change at General Availability` と明記されていたため採用しない
- `parallelism` のチューニング
- `machine.image` の変更（世代は `resource_class` で決まるため不要）
- `docker_layer_caching`（DLC）の見直し。**200 credits/job 固定でクラス・世代に依存しません**
